### PR TITLE
IOS-8 | Добавлено удаление из памяти устройства

### DIFF
--- a/VKNews/VKNews/Streams/SnippetStream/SnippetDetailScreen/Presentation/SnippetDetailViewModel.swift
+++ b/VKNews/VKNews/Streams/SnippetStream/SnippetDetailScreen/Presentation/SnippetDetailViewModel.swift
@@ -23,6 +23,7 @@ protocol SnippetDetailViewModelProtocol: AnyObject {
     func didTapCancelButton()
     func didTapAlertButton()
     func didTapBackButton()
+    func didTapDeleteButton()
     // Display data
     func showError(errorMessage: String)
     func savedSuccessful(snippetID: String, title: String, description: String)
@@ -103,6 +104,11 @@ extension SnippetDetailViewModel {
     }
 
     func didTapBackButton() {
+        coordinator?.openPreviousScreen()
+    }
+
+    func didTapDeleteButton() {
+        sharedViewModel?.deleteSnippet(snippet: snippet)
         coordinator?.openPreviousScreen()
     }
 }

--- a/VKNews/VKNews/Streams/SnippetStream/SnippetDetailScreen/Presentation/Subviews/SnippetDetailView+Subviews.swift
+++ b/VKNews/VKNews/Streams/SnippetStream/SnippetDetailScreen/Presentation/Subviews/SnippetDetailView+Subviews.swift
@@ -65,6 +65,8 @@ extension SnippetDetailView {
             }
 
             Spacer()
+
+            deleteButton
         }
         .padding(.horizontal)
         .padding(.bottom)
@@ -171,16 +173,31 @@ extension SnippetDetailView {
             )
         }
     }
+
+    var deleteButton: some View {
+        Button {
+            viewModel.didTapDeleteButton()
+        } label: {
+            Image(systemName: "trash")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .foregroundStyle(.foreground)
+                .frame(width: 20)
+                .frame(width: 40, height: 40)
+        }
+    }
 }
 
 // MARK: - Preview
 
 #Preview("Mockable") {
+
     NavigationStack {
         SnippetDetailView(
             viewModel: SnippetDetailViewModel(snippet: .mockData)
         )
     }
+    .environment(Coordinator())
 }
 
 // MARK: - Constants

--- a/VKNews/VKNews/Streams/SnippetStream/YouTubeListScreen/Presentation/Subviews/YouTubeListView+Subviews.swift
+++ b/VKNews/VKNews/Streams/SnippetStream/YouTubeListScreen/Presentation/Subviews/YouTubeListView+Subviews.swift
@@ -61,7 +61,10 @@ extension YouTubeListView {
     var contentContainer: some View {
         ForEach(viewModel.snippets, id: \.hashValue) { snippet in
             LazyVStack {
-                YouTubeSnippetView(snippet: snippet).onAppear {
+                YouTubeSnippetView(
+                    snippet: snippet,
+                    deleteHandler: viewModel.deleteSnippet
+                ).onAppear {
                     viewModel.loadMoreData(with: snippet)
                 }
                 .onTapGesture {
@@ -71,7 +74,8 @@ extension YouTubeListView {
         }
 
         if viewModel.showMoreLoading {
-            ProgressView().padding()
+            ProgressView()
+                .padding()
         }
     }
 }

--- a/VKNews/VKNews/Streams/SnippetStream/YouTubeListScreen/Presentation/YouTubeListViewModel+Mock.swift
+++ b/VKNews/VKNews/Streams/SnippetStream/YouTubeListScreen/Presentation/YouTubeListViewModel+Mock.swift
@@ -80,6 +80,13 @@ extension YouTubeListViewModelMock {
         }
     }
 
+    func deleteSnippet(snippet: YouTubeSnippetModel) {
+        guard let index = (snippets.firstIndex { $0.id == snippet.id }) else {
+            return
+        }
+        snippets.remove(at: index)
+    }
+
     func showError(errorMessage: String) {}
 
     func showSnippets(_ data: [YouTubeSnippetModel], nextPageToken: String?) {}

--- a/VKNews/VKNews/Streams/SnippetStream/YouTubeListScreen/Presentation/YouTubeListViewModel.swift
+++ b/VKNews/VKNews/Streams/SnippetStream/YouTubeListScreen/Presentation/YouTubeListViewModel.swift
@@ -31,6 +31,7 @@ protocol YouTubeListViewModelProtocol: AnyObject {
     func didEditSnippet(snippet: YouTubeSnippetModel)
     // Actions
     func didTapSnippetCard(snippet: YouTubeSnippetModel)
+    func deleteSnippet(snippet: YouTubeSnippetModel)
 }
 
 // MARK: - YouTubeListViewModel
@@ -130,7 +131,7 @@ extension YouTubeListViewModel {
 
     func addSnippetsFromMemory(_ data: [YouTubeSnippetModel]) {
         mergeSnippets(newSnippets: data)
-        screenState = snippets.isEmpty ? .emptyView : .success
+        screenState = .success
         lastSnippet = data.last
     }
 
@@ -166,6 +167,15 @@ extension YouTubeListViewModel {
 
     func didTapSnippetCard(snippet: YouTubeSnippetModel) {
         router?.openSnippetCard(with: snippet)
+    }
+
+    func deleteSnippet(snippet: YouTubeSnippetModel) {
+        guard let index = (snippets.firstIndex { $0.id == snippet.id }) else {
+            return
+        }
+        snippets.remove(at: index)
+
+        interactor?.deleteSnippetFromMemory(snippet: snippet)
     }
 }
 


### PR DESCRIPTION
- [X] Заголовок МР соответствует шаблону "IOS-##### | Что сделано, по-русски, предложение в совершенном виде глагола"
- [X] Добавлено описание к МРу
- [X] Название ветки соответствует формату feature/username/IOS-2_something_about_task
- [X] Проверено на наличие лишних пробелов и отступов

## Что было сделано:
Помимо удаления через жест, добавлена возможность удаления по кнопке. Удалять можно только элементы, которые были достаны из памяти устройства и помечены меткой saved

## (Optional) Скриншот экрана

<details>
<summary>Смотреть фото</summary>
<img width="521" alt="image" src="https://github.com/user-attachments/assets/dab46fa6-335e-4c6d-b3c1-f4f0a9bc4fa0">
<img width="504" alt="image" src="https://github.com/user-attachments/assets/062db1fe-cf32-4f6f-92a4-77fbe43a5d1d">

</details>

## 🔗 Полезные ссылки 
[Ссылка на задачу]()